### PR TITLE
Fix Tooltips not showing when scrolling past initial screen size

### DIFF
--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -12,9 +12,11 @@ export const Tooltip: React.FC<TooltipProps> = ({ rowNames, field, panelId }) =>
   const [mousePosition, setMousePosition] = useState({ mouseX: 100, mouseY: 100 });
 
   const updateMousePosition = (e: any) => {
-    setMousePosition({ mouseX: e.clientX, mouseY: e.clientY });
+    setMousePosition({
+      mouseX: e.clientX + window.scrollX,
+      mouseY: e.clientY + window.scrollY,
+    });
   };
-
   useEffect(() => {
     window.addEventListener('mousemove', updateMousePosition);
     const pathClass = `.sankey-path${panelId}`;


### PR DESCRIPTION
The tooltips don't show when adding multiple panels in a dashboard and scrolling past initial screen-height and -width. 

This is my naive try to fix it